### PR TITLE
Byteplanes

### DIFF
--- a/encode.cc
+++ b/encode.cc
@@ -60,14 +60,11 @@ int main(int argc, char* argv[]) {
 
   size_t framesize = xsize * ysize * 2;
 
-  std::vector<uint8_t> buffer(framesize);
-
-
-  fpvc::Encoder encoder(num_threads);
+  fpvc::Encoder encoder(num_threads, shift, big_endian);
 
   bool initialized = false;
 
-  // Rotate through multiple memory buffers for the input image such that all
+ // Rotate through multiple memory buffers for the input image such that all
   // threads / queued tasks have their own buffer.
   size_t num_buffers = encoder.MaxQueued();
   std::vector<uint16_t> buffers[num_buffers];
@@ -83,10 +80,9 @@ int main(int argc, char* argv[]) {
   };
 
   while (std::cin) {
-    if (!std::cin.read((char*)buffer.data(), framesize)) break;
-
     uint16_t* img = buffers[buffer_index].data();
-    fpvc::ExtractFrame(buffer.data(), xsize, ysize, shift, big_endian, img);
+
+    if (!std::cin.read(reinterpret_cast<char*>(img), framesize)) break;
 
     if (!initialized) {
       initialized = true;

--- a/fusion_power_video.cc
+++ b/fusion_power_video.cc
@@ -373,6 +373,13 @@ bool DecompressImage(const uint16_t* delta_frame,
 
 Frame Frame::EMPTY(0, 0);
 
+// std::endian doc explicitly says that std::endian::native may be neither 
+// std::endian::little nor std::endian::big (on mixed endian systems).
+// Therefore this determines the endianess of uint16_t at initialization time
+static const uint16_t SYSTEM_UINT16_ENDIAN_TEST = 0x0100;
+static const bool SYSTEM_UINT16_BIG_ENDIAN = 
+      1 == reinterpret_cast<const uint8_t*>(&SYSTEM_UINT16_ENDIAN_TEST)[0];
+
 Frame::Frame(size_t xsize, size_t ysize, const uint16_t* image,
              int shift_to_left_align, bool big_endian) {
   xsize_ = xsize;
@@ -380,6 +387,8 @@ Frame::Frame(size_t xsize, size_t ysize, const uint16_t* image,
   size_ = xsize_ * ysize_;
   state_ = FrameState::EMPTY;
   flags_ = FrameFlags::NONE;
+
+  bool switch_endian = big_endian != SYSTEM_UINT16_BIG_ENDIAN;
   
   uint8_t non_zero_low = 0;
 
@@ -388,35 +397,37 @@ Frame::Frame(size_t xsize, size_t ysize, const uint16_t* image,
     high_.reserve(size_);
     low_.reserve(size_);
 
-    if (big_endian && (shift_to_left_align == 0)) {
+    if (switch_endian) {
+      if (shift_to_left_align == 0) {
 
-      for (size_t i = 0; i < size_; ++i) {
-        uint16_t pixel = image[i];
-        high_.push_back(pixel & 0xff);
-        pixel = (pixel >> 8) & 0xff;
-        low_.push_back(pixel);
-        non_zero_low |= pixel;
+        for (size_t i = 0; i < size_; ++i) {
+          uint16_t pixel = image[i];
+          high_.push_back(pixel & 0xff);
+          pixel = (pixel >> 8) & 0xff;
+          low_.push_back(pixel);
+          non_zero_low |= pixel;
+        }
+
+      } else if (shift_to_left_align == 8) {
+
+        for (size_t i = 0; i < size_; ++i) {
+          high_.push_back((image[i] >> 8) & 0xff);
+        }
+
+      } else {
+
+        int low_shift = 8 - shift_to_left_align;
+        int low_shift_high = 16 - shift_to_left_align;
+        for (size_t i = 0; i < size_; ++i) {
+          uint16_t pixel = image[i];
+          high_.push_back(((pixel << shift_to_left_align) | (pixel >> low_shift_high)) & 0xff);
+          pixel = (pixel >>  low_shift) & 0xff;
+          low_.push_back(pixel);
+          non_zero_low |= pixel;
+        }
+
       }
-
-    } else if (big_endian && (shift_to_left_align == 8)) {
-
-      for (size_t i = 0; i < size_; ++i) {
-        high_.push_back((image[i] >> 8) & 0xff);
-      }
-
-    } else if (big_endian) {
-
-      int low_shift = 8 - shift_to_left_align;
-      int low_shift_high = 16 - shift_to_left_align;
-      for (size_t i = 0; i < size_; ++i) {
-        uint16_t pixel = image[i];
-        high_.push_back(((pixel << shift_to_left_align) | (pixel >> low_shift_high)) & 0xff);
-        pixel = (pixel >>  low_shift) & 0xff;
-        low_.push_back(pixel);
-        non_zero_low |= pixel;
-      }
-      
-    // LITTLE ENDIAN
+    // data endianess == system endianess
     } else if (shift_to_left_align == 0) {
 
       for (size_t i = 0; i < size_; ++i) {

--- a/fusion_power_video.h
+++ b/fusion_power_video.h
@@ -26,16 +26,7 @@
 
 namespace fpvc {
 
-// Helper functions to convert 16-bit image frames to/from the raw file format.
-
-// Extracts a frame from raw images with 16 bits per pixel, of which 12 bits
-// are used.
-// The input must have xsize * ysize * 2 bytes, the output xsize * ysize value  s.
-// shift = how much to left shift the value to place the MSB of the 12-bit
-// value in the MSB of the 16-bit output.
-void ExtractFrame(const uint8_t* frame, size_t xsize,
-                  size_t ysize, int shift, bool big_endian,
-                  uint16_t* out);
+// Helper function to convert 16-bit image frames to/from the raw file format.
 
 // Converts 16-bit frame back to the original raw file format.
 void UnextractFrame(const uint16_t* img,
@@ -107,7 +98,9 @@ class Frame {
   uint8_t preview(size_t offset) const { return preview_[offset]; }
   size_t previewSize() const { return preview_.size(); }
 
-  Frame(size_t xsize = 0, size_t ysize = 0, const uint16_t* image = nullptr);
+  Frame(size_t xsize = 0, size_t ysize = 0, const uint16_t* image = nullptr,
+        int shift_to_left_align = 0, bool big_endian = false);
+  Frame(size_t xsize, size_t ysize, const uint8_t* image);
 
   void Compress(Frame &delta_frame = EMPTY);
   void OutputCore(std::vector<uint8_t> *out);
@@ -159,7 +152,7 @@ class Encoder {
  public:
   // Uses num_threads worker threads, or disables multithreading if num_threads
   // is 0.
-  Encoder(size_t num_threads = 8);
+  Encoder(size_t num_threads = 8, int shift_to_left_align = 0, bool big_endian = false);
 
   // The payload is an optional argument to pass from calls to the callback.
   typedef std::function<void(const uint8_t* compressed, size_t size,
@@ -232,6 +225,9 @@ class Encoder {
   Frame delta_frame_;
   std::vector<size_t> frame_offsets;
   size_t bytes_written = 0;
+
+  int shift_to_left_align_ = 0;
+  bool big_endian_ = false;
 };
 
 }  // namespace fpvc

--- a/fusion_power_video.h
+++ b/fusion_power_video.h
@@ -82,7 +82,20 @@ enum FrameFlags {
 };
 
 class Frame {
+  size_t xsize_ = 0;
+  size_t ysize_ = 0;
+  size_t size_ = 0;
+  uint8_t flags_ = FrameFlags::NONE; // FrameFlags
+  int state_ = FrameState::EMPTY; // FrameState
+
+ protected:
+  std::vector<uint8_t> preview_;
+  std::vector<uint8_t> high_;
+  std::vector<uint8_t> low_;
+
  public:
+  static Frame EMPTY;
+
   size_t xsize() const { return xsize_; }
   size_t ysize() const { return ysize_; }
   uint8_t flags() const { return flags_; }
@@ -94,28 +107,18 @@ class Frame {
   uint8_t preview(size_t offset) const { return preview_[offset]; }
   size_t previewSize() const { return preview_.size(); }
 
-  Frame(const uint16_t* image, size_t xsize, size_t ysize);
+  Frame(size_t xsize = 0, size_t ysize = 0, const uint16_t* image = nullptr);
 
-  void Compress(Frame &delta_frame);
-
+  void Compress(Frame &delta_frame = EMPTY);
   void OutputCore(std::vector<uint8_t> *out);
   void OutputFull(std::vector<uint8_t> *out);
-
+  
  private:
 
   void GeneratePreview();
   void OptionallyApplyDeltaPrediction(Frame &delta_frame);
   void OptionallyApplyClampedGradientPrediction();
   void ApplyBrotliCompression();
-
-  size_t xsize_;
-  size_t ysize_;
-  size_t size_;
-  uint8_t flags_; // FrameFlags
-  int state_; // FrameState
-  std::vector<uint8_t> preview_;
-  std::vector<uint8_t> high_;
-  std::vector<uint8_t> low_;
 };
 
 // Rnadom access decoder: requires random access to the entire data file,
@@ -226,7 +229,7 @@ class Encoder {
   size_t xsize_;
   size_t ysize_;
 
-  std::vector<uint16_t> delta_frame_;
+  Frame delta_frame_;
   std::vector<size_t> frame_offsets;
   size_t bytes_written = 0;
 };


### PR DESCRIPTION
Hi Lode,

i believe tha encapsulating these operations into the container-class Frame makes the code easier to understand and follow. I was also able to reduce the number of copy operations from buffer to buffer in the encoder before the byte plane splitting. In total, the encoding seems to be marginaly faster after the refactoring.

Kind regards,
Simon